### PR TITLE
Functions that are extern should stay extern (#201)

### DIFF
--- a/cparser/Elab.ml
+++ b/cparser/Elab.ml
@@ -172,7 +172,7 @@ let combine_toplevel_definitions loc env s old_sto old_ty sto ty =
 	error loc "static declaration of '%s' follows non-static declaration" s;
         sto
     | Storage_static,_ -> Storage_static (* Static stays static *)
-    | Storage_extern,_ -> sto
+    | Storage_extern,_ -> if is_function_type env new_ty then Storage_extern else sto
     | Storage_default,Storage_extern ->
       if is_global_defined s && is_function_type env ty then
         warning loc Extern_after_definition "this extern declaration follows a non-extern definition and is ignored";


### PR DESCRIPTION
In ISO C, inline functions behaves differently whether they have been declared `extern` at least once or not (i.e. all the declarations have no `extern` and no `static` modifier).

Hence, functions that have been declared / defined `extern` once should remain `extern` when redeclared without `extern`.  This gives the ISO C behavior for inline functions and has no impact for non-inline functions.